### PR TITLE
fix assert for dev >= 2

### DIFF
--- a/src/cmn_devmem.py
+++ b/src/cmn_devmem.py
@@ -964,7 +964,7 @@ class DTMWatchpoint:
             config |= (dev0 << 0)
             if self.dev >= 2:
                 # dev_sel is actually the port number, not the device number
-                assert self.dev < self.xp.n_device_ports(), "%s: invalid dev_sel=%u" % (self, self.dev)
+                assert self.dev < self.dtm.xp.n_device_ports(), "%s: invalid dev_sel=%u" % (self, self.dev)
                 dev1 = self.dev >> 1
                 config |= (dev1 << 17)
         if self.grp is not None:


### PR DESCRIPTION
If node 0x6c connect to P2 in command:
`cmn_capture.py --node 0x6c --xp 0x68 --chn 0 --samples 512`

We have a problem:
```

Traceback (most recent call last):
  File "/home/developer/cmn-tools/src/cmn_capture.py", line 921, in <module>
    cap = ts.trace()
  File "/home/developer/cmn-tools/src/cmn_capture.py", line 802, in trace
    self.trace_start()
    ~~~~~~~~~~~~~~~~^^
  File "/home/developer/cmn-tools/src/cmn_capture.py", line 744, in trace_start
    self.configure_dtm(dtm)
    ~~~~~~~~~~~~~~~~~~^^^^^
  File "/home/developer/cmn-tools/src/cmn_capture.py", line 683, in configure_dtm
    dtm.dtm_wp_set(off, w)
    ~~~~~~~~~~~~~~^^^^^^^^
  File "/home/developer/cmn-tools/src/cmn_devmem.py", line 1186, in dtm_wp_set
    self.dtm_write64(CMN_DTM_WP0_CONFIG_off+(wp*24), w.encode())
                                                     ~~~~~~~~^^
  File "/home/developer/cmn-tools/src/cmn_devmem.py", line 967, in encode
    assert self.dev < self.xp.n_device_ports(), "%s: invalid dev_sel=%u" % (self, self.dev)
                      ^^^^^^^
AttributeError: 'DTMWatchpoint' object has no attribute 'xp'. Did you mean: 'up'?
```
